### PR TITLE
Buck build system support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 test
 driver
 driver.cpp
+.buckd
+.buckconfig
+buck-out

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 *.dSYM
 test
-driver
-driver.cpp
 .buckd
 .buckconfig
 buck-out

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,11 @@
+prebuilt_cxx_library(
+  name = 'apathy', 
+  header_namespace = 'apathy',
+  header_only = True,
+  exported_headers = [
+    'path.hpp',
+  ],
+  visibility = [
+    'PUBLIC',
+  ],
+)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ in your code (this works particularly well with
 
 It imports a single member `Path` in the `apathy` namespace.
 
+You can also use the supplied `BUCK` file to import Apathy into your project. The target is `apathy`.
+
 Usage
 =====
 Most of the path manipulators return a reference to the current path, so that

--- a/examples/BUCK
+++ b/examples/BUCK
@@ -1,0 +1,9 @@
+cxx_binary(
+  name = 'whereAmI',
+  srcs = [
+    'whereAmI.cpp',
+  ],
+  deps = [
+   '//:apathy',
+  ],
+)

--- a/examples/whereAmI.cpp
+++ b/examples/whereAmI.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+
+#include <apathy/path.hpp>
+
+int main() {
+  std::cout << "You are at: \n" 
+    << apathy::Path::cwd().string() 
+    << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Added the necessary BUCK files to allow building with [Buck](https://buckbuild.com/) out-of-the-box. These sit alongside the `make` file, which is unchanged. 